### PR TITLE
Release v1.2.0

### DIFF
--- a/src/backend/API.ts
+++ b/src/backend/API.ts
@@ -1,6 +1,6 @@
 import * as Core from '../core/index.js';
 
-import { Headers, fetch } from 'cross-fetch';
+import { Headers, Request, fetch } from 'cross-fetch';
 import { storageV8N, v8n } from '../core/v8n.js';
 
 import type { Graph } from './Graph';
@@ -130,6 +130,7 @@ export class API extends Core.API<Graph> {
 
   private async __fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
     let token = JSON.parse(this.storage.getItem(API.ACCESS_TOKEN) ?? 'null') as StoredToken | null;
+    const request = new Request(input, init);
 
     if (token !== null) {
       const expiresAt = new Date(token.date_created).getTime() + token.expires_in * 1000;
@@ -155,15 +156,14 @@ export class API extends Core.API<Graph> {
       }
     }
 
-    const headers = new Headers(init?.headers);
+    const headers = request.headers;
     const method = init?.method?.toUpperCase() ?? 'GET';
-    const url = typeof input === 'string' ? input : input.url;
 
     if (!headers.get('Authorization') && token) headers.set('Authorization', `Bearer ${token.access_token}`);
     if (!headers.get('Content-Type')) headers.set('Content-Type', 'application/json');
     if (!headers.get('FOXY-API-VERSION')) headers.set('FOXY-API-VERSION', this.version);
 
-    this.console.trace(`${method} ${url}`);
-    return fetch(input, { ...init, headers });
+    this.console.trace(`${method} ${request.url}`);
+    return fetch(request);
   }
 }

--- a/src/core/API/API.ts
+++ b/src/core/API/API.ts
@@ -1,3 +1,4 @@
+import { Headers, Request, Response, fetch } from 'cross-fetch';
 import consola, { Consola, LogLevel } from 'consola';
 import { storageV8N, v8n } from '../v8n.js';
 
@@ -5,7 +6,6 @@ import { AuthError } from './AuthError.js';
 import type { Graph } from '../Graph';
 import MemoryStorage from 'fake-storage';
 import { Node } from './Node.js';
-import { fetch } from 'cross-fetch';
 
 /** API constructor parameters. */
 type Init = {
@@ -45,6 +45,24 @@ type Init = {
  * your own client, consider extending this class for consistency.
  */
 export class API<TGraph extends Graph> extends Node<TGraph> {
+  /**
+   * Polyfilled version of the built-in `Response` class. If you need to check the return value of `.fetch()`,
+   * use this class instead of the built-in one to avoid [this issue](https://github.com/github/fetch/issues/860).
+   */
+  static readonly WHATWGResponse = Response;
+
+  /**
+   * Polyfilled version of the built-in `Request` class. If you need to pass an instance of `Request` to `.fetch()`,
+   * use this class instead of the built-in one to avoid [this issue](https://github.com/github/fetch/issues/860).
+   */
+  static readonly WHATWGRequest = Request;
+
+  /**
+   * Polyfilled version of the built-in `Headers` class. If you need to pass an instance of `Headers` to `.fetch()`,
+   * use this class instead of the built-in one to avoid [this issue](https://github.com/github/fetch/issues/860).
+   */
+  static readonly WHATWGHeaders = Headers;
+
   static readonly AuthError = AuthError;
 
   static readonly Node = Node;

--- a/tests/backend/API.test.ts
+++ b/tests/backend/API.test.ts
@@ -222,7 +222,7 @@ describe('Backend', () => {
       await api.fetch(url);
 
       const headers = new Headers({ ...commonHeaders, Authorization: `Bearer ${sampleToken.access_token}` });
-      expect(fetchMock).toHaveBeenCalledWith(url, { headers });
+      expect(fetchMock).toHaveBeenCalledWith(new Request(url, { headers }));
 
       fetchMock.mockClear();
     });
@@ -248,7 +248,7 @@ describe('Backend', () => {
       });
 
       const headers = new Headers({ ...commonHeaders, Authorization: `Bearer ${sampleToken.access_token}` });
-      expect(fetchMock).toHaveBeenNthCalledWith(2, url, { headers });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, new Request(url, { headers }));
 
       fetchMock.mockClear();
     });
@@ -272,7 +272,7 @@ describe('Backend', () => {
       });
 
       const headers = new Headers({ ...commonHeaders, Authorization: `Bearer ${sampleToken.access_token}` });
-      expect(fetchMock).toHaveBeenNthCalledWith(2, url, { headers });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, new Request(url, { headers }));
 
       fetchMock.mockClear();
     });
@@ -295,22 +295,37 @@ describe('Backend', () => {
         method: 'POST',
       });
 
-      expect(fetchMock).toHaveBeenNthCalledWith(2, url, { headers: new Headers(commonHeaders) });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, new Request(url, { headers: commonHeaders }));
 
       fetchMock.mockClear();
     });
 
-    it('supports complex fetch requests', async () => {
+    it('supports complex fetch requests with detailed arguments', async () => {
       fetchMock.mockImplementation(() => Promise.resolve(new Response(null, { status: 500 })));
 
       const api = new BackendAPI(commonInit);
-      const info = new Request(BackendAPI.BASE_URL.toString());
+      const info = BackendAPI.BASE_URL.toString();
       const init = { headers: { foo: 'bar' }, method: 'POST' };
 
       await api.fetch(info, init);
 
       const headers = new Headers({ ...commonHeaders, ...init.headers });
-      expect(fetchMock).toHaveBeenLastCalledWith(info, { ...init, headers });
+      expect(fetchMock).toHaveBeenLastCalledWith(new Request(info, { ...init, headers }));
+
+      fetchMock.mockClear();
+    });
+
+    it('supports complex fetch requests with Request instances', async () => {
+      fetchMock.mockImplementation(() => Promise.resolve(new Response(null, { status: 500 })));
+
+      const api = new BackendAPI(commonInit);
+      const info = BackendAPI.BASE_URL.toString();
+      const init = { headers: { foo: 'bar' }, method: 'POST' };
+
+      await api.fetch(new Request(info, init));
+
+      const headers = new Headers({ ...commonHeaders, ...init.headers });
+      expect(fetchMock).toHaveBeenLastCalledWith(new Request(info, { ...init, headers }));
 
       fetchMock.mockClear();
     });

--- a/tests/customer/API.test.ts
+++ b/tests/customer/API.test.ts
@@ -85,6 +85,18 @@ describe('Customer', () => {
       fetchMock.mockClear();
     });
 
+    it('supports Request instances in .fetch()', async () => {
+      fetchMock.mockImplementation(() => Promise.resolve(new Response(null)));
+
+      const api = new CustomerAPI(commonInit);
+      const url = api.base.toString();
+
+      await api.fetch(new Request(url));
+
+      expect(fetchMock).toHaveBeenCalledWith(new Request(url, { headers: commonHeaders }));
+      fetchMock.mockClear();
+    });
+
     it('can create a session with .signIn()', async () => {
       fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify(sampleSession))));
 


### PR DESCRIPTION
## Bug Fixes

- Starting with this update, all `.fetch()` calls on classes extending `Core.API` will accept and correctly process `Request` instances as first argument as per the Fetch API spec. Note: please use `Core.API.WHATWGRequest` in your code for maximum compatibility – `whatwg-fetch` (used by `cross-fetch` that we rely on) doesn't work with the built-in `Request` instances.

## Features

- For ease of use and the reasons outlined above, all classes extending `Core.API` will now include `WHATWGRequest`, `WHATWGResponse` and `WHATWGHeaders` static properties, exposing the respective classes from `whatwg-fetch`.