### PR TITLE
feat: Core.BooleanSelector

### DIFF
--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -167,6 +167,19 @@ export class BooleanSelector {
     return this.__value;
   }
 
+  /**
+   * Converts this selector to an attribute value.
+   *
+   * @example
+   * new BooleanSelector('foo:bar').toAttribute() // => "foo:bar"
+   * new BooleanSelector('').toAttribute() // => null
+   *
+   * @returns attribute value representing this selector.
+   */
+  toAttribute(): string | null {
+    return this.__value.trim().length === 0 ? null : this.toString();
+  }
+
   private static __stringify(tree: Tree, path = ''): string {
     if (tree.only) {
       return Object.entries(tree.only).reduce((output, [key, subtree]) => {

--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -77,6 +77,28 @@ export class BooleanSelector {
     return falseBooleanSelectorSingleton;
   }
 
+  /**
+   * Creates a `BooleanSelector` instance from an attribute value according to the following rules:
+   *
+   * - boolean selector constructed from a `null` value will always return `false` from `.allows()`;
+   * - if attribute value is empty or matches `truthyValue`, a boolean selector will always return `true` from `.allows()`;
+   * - in every other case attribute value will be parsed as boolean selector.
+   *
+   * @example
+   * const value = element.getAttribute('disabled');
+   * BooleanSelector.fromAttribute(value) // => [object BooleanSelector]
+   *
+   * @param value attribite value
+   * @param truthyValue additional attribute value that must be treated as truthy (use attribute name here to be spec-compliant)
+   * @returns `BooleanSelector` instance constructed from the given attribite value
+   */
+  static fromAttribute(value: string | null, truthyValue?: string): BooleanSelector {
+    if (value === null) return BooleanSelector.False;
+    if (value === '' || value === truthyValue) return BooleanSelector.True;
+    return new BooleanSelector(value);
+  }
+
+
   private static __processors: Record<Entity, Processor> = {
     [Entity.List](output, character) {
       /* istanbul ignore next */

--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -131,13 +131,13 @@ export class BooleanSelector {
    * Checks if current selector includes rules for the given top-level identifier.
    *
    * @example
-   * new BooleanSelector('foo:bar').allows('foo') // => true
-   * new BooleanSelector('foo:bar').allows('bar') // => false
+   * new BooleanSelector('foo:bar').matches('foo') // => true
+   * new BooleanSelector('foo:bar').matches('bar') // => false
    *
    * @param id identifier to look for
    * @returns `true` is current selector includes rules for the given identifier
    */
-  allows(id: string): boolean {
+  matches(id: string): boolean {
     return !!this.__tree.only?.[id] || this.__tree.not?.includes(id) === false;
   }
 
@@ -145,12 +145,12 @@ export class BooleanSelector {
    * Zooms on the given top-level identifier.
    *
    * @example
-   * new BooleanSelector('foo:bar:baz').filter('foo').toString() // => "bar:baz"
+   * new BooleanSelector('foo:bar:baz').zoom('foo').toString() // => "bar:baz"
    *
    * @param id identifier to look for
    * @returns `true` is current selector includes rules for the given identifier
    */
-  filter(id: string): BooleanSelector {
+  zoom(id: string): BooleanSelector {
     const subtree = this.__tree.only?.[id] ?? {};
     return new BooleanSelector(BooleanSelector.__stringify(subtree));
   }

--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -64,6 +64,19 @@ export class BooleanSelector {
     return trueBooleanSelectorSingleton;
   }
 
+  /**
+   * Helper selector that doesn't match any identifier on any level.
+   *
+   * @example
+   * BooleanSelector.False.matches('anything') // => false
+   * BooleanSelector.False.zoom('thing').matches('stuff') // => false
+   *
+   * @returns `BooleanSelector` singleton
+   */
+  static get False(): BooleanSelector {
+    return falseBooleanSelectorSingleton;
+  }
+
   private static __processors: Record<Entity, Processor> = {
     [Entity.List](output, character) {
       /* istanbul ignore next */
@@ -240,4 +253,19 @@ class TrueBooleanSelector extends BooleanSelector {
   }
 }
 
+class FalseBooleanSelector extends BooleanSelector {
+  matches(): boolean {
+    return false;
+  }
+
+  zoom(): this {
+    return this;
+  }
+
+  toAttribute(): string | null {
+    return null;
+  }
+}
+
+const falseBooleanSelectorSingleton = new FalseBooleanSelector('');
 const trueBooleanSelectorSingleton = new TrueBooleanSelector('');

--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -1,0 +1,201 @@
+const enum Entity {
+  List,
+  Set,
+}
+
+type Tree = { only?: Record<string, Tree>; not?: string[] };
+type Output = { entity: Entity; buffer: string; tree: Tree; branch: Tree | string[] };
+type Processor = (output: Output, character: string) => void;
+
+/**
+ * Boolean selector is an HTML boolean attribute value format that allows
+ * developers to write configurations for elements deep in a shadow DOM. Here's
+ * what it looks like:
+ *
+ * ```text
+ * direct-child-one:nested-child:not=descendant-one,descendant-two direct-child-two
+ * ```
+ *
+ * When used with the "disabled" attribute, the code above could translate to: "Disable
+ * everything except for the descendant-one and descendant-two in the nested-child that
+ * belongs to direct-child-one; disable direct-child-two entirely."
+ *
+ * Boolean selector is always a list, where items are separated by whitespace (as much
+ * as you need, including line breaks):
+ *
+ * ```text
+ * item-one item-two item-three
+ * ```
+ *
+ * Each item is a path that consists of identifiers (lowercase characters from a to z or a dash)
+ * separated by a colon:
+ *
+ * ```text
+ * parent:child:nested-child
+ * ```
+ *
+ * By default, only specified paths will be selected. To select everything except for certain paths,
+ * add the `not=` modifier to the end of the path (or at the top level):
+ *
+ * ```text
+ * parent:child:not=exception
+ * ```
+ *
+ * You can specify multiple values by separating them with a comma and optionally a whitespace:
+ *
+ * ```text
+ * parent:child:not=exception-one, exception-two
+ * ```
+ *
+ * Only lowercase a-z letters, colon, comma, dash and whitespace are allowed in the selectors. An attempt
+ * to use a character outside of this set will result in a `SyntaxError`.
+ */
+export class BooleanSelector {
+  private static __processors: Record<Entity, Processor> = {
+    [Entity.List](output, character) {
+      /* istanbul ignore next */
+      if (Array.isArray(output.branch)) throw new SyntaxError('Paths are not allowed in sets.');
+
+      if (character === '=') {
+        if (output.buffer === 'not') {
+          const newBranch = output.branch[output.buffer] ?? [];
+
+          output.branch[output.buffer] = newBranch;
+          output.entity = Entity.Set;
+          output.branch = newBranch;
+          output.buffer = '';
+
+          return;
+        } else {
+          throw new SyntaxError(`Unknown modifier "${output.buffer}".`);
+        }
+      }
+
+      if (/^\s$/.test(character) || character === ':') {
+        const selector = output.buffer;
+        const newBranch = output.branch.only?.[selector] ?? {};
+
+        output.branch.only = { ...output.branch.only, [selector]: newBranch };
+        output.branch = /^\s$/.test(character) ? output.tree : newBranch;
+        output.buffer = '';
+        return;
+      }
+
+      if (/^[a-z]|-$/.test(character)) {
+        output.buffer += character;
+        return;
+      }
+
+      throw new SyntaxError(`Expected [a-z], "-", ":" or a whitespace, but got "${character}" instead.`);
+    },
+
+    [Entity.Set](output, character) {
+      /* istanbul ignore next */
+      if (!Array.isArray(output.branch)) throw new SyntaxError('Unexpected set item.');
+
+      if (output.buffer.length === 0 && /^\s$/.test(character)) return;
+
+      if (character === ',' || /^\s$/.test(character)) {
+        output.entity = character === ',' ? Entity.Set : Entity.List;
+        output.branch.push(output.buffer);
+        output.branch = character === ',' ? output.branch : output.tree;
+        output.buffer = '';
+        return;
+      }
+
+      if (/^[a-z]|-$/.test(character)) {
+        output.buffer += character;
+        return;
+      }
+
+      throw new SyntaxError(`Expected [a-z], "-", "," or a whitespace, but got "${character}" instead.`);
+    },
+  };
+
+  private __value: string;
+
+  private __tree: Tree;
+
+  /**
+   * Parses the boolean selector value and creates an instance
+   * of the `BooleanSelector` class.
+   *
+   * @param value boolean selector value, e.g. `foo:bar baz:not=qux`
+   */
+  constructor(value: string) {
+    this.__value = value;
+    this.__tree = BooleanSelector.__parse(value);
+  }
+
+  /**
+   * Checks if current selector includes rules for the given top-level identifier.
+   *
+   * @example
+   * new BooleanSelector('foo:bar').allows('foo') // => true
+   * new BooleanSelector('foo:bar').allows('bar') // => false
+   *
+   * @param id identifier to look for
+   * @returns `true` is current selector includes rules for the given identifier
+   */
+  allows(id: string): boolean {
+    return !!this.__tree.only?.[id] || this.__tree.not?.includes(id) === false;
+  }
+
+  /**
+   * Zooms on the given top-level identifier.
+   *
+   * @example
+   * new BooleanSelector('foo:bar:baz').filter('foo').toString() // => "bar:baz"
+   *
+   * @param id identifier to look for
+   * @returns `true` is current selector includes rules for the given identifier
+   */
+  filter(id: string): BooleanSelector {
+    const subtree = this.__tree.only?.[id] ?? {};
+    return new BooleanSelector(BooleanSelector.__stringify(subtree));
+  }
+
+  /**
+   * Converts this selector to string.
+   *
+   * @example
+   * new BooleanSelector('foo:bar').toString() // => "foo:bar"
+   *
+   * @returns serialized representation of this selector
+   */
+  toString(): string {
+    return this.__value;
+  }
+
+  private static __stringify(tree: Tree, path = ''): string {
+    if (tree.only) {
+      return Object.entries(tree.only).reduce((output, [key, subtree]) => {
+        const result = BooleanSelector.__stringify(subtree, path.length === 0 ? key : `${path}:${key}`);
+        return output.length === 0 ? result : `${output} ${result}`;
+      }, '');
+    }
+
+    if (tree.not) return `${path.length === 0 ? '' : `${path}:`}not=${tree.not.join(',')}`;
+
+    return path;
+  }
+
+  private static __parse(value: string): Tree {
+    const tree = {};
+    const output: Output = { branch: tree, buffer: '', entity: Entity.List, tree };
+
+    Array.from(`${value} `).forEach((character, position) => {
+      try {
+        BooleanSelector.__processors[output.entity](output, character);
+      } catch (err) {
+        const hint = 'This error occured at: ';
+        const preview = value.substring(position - 30, position + 30);
+        const pointer = `${' '.repeat(hint.length + Math.min(preview.length, 29))}^`;
+
+        throw new SyntaxError([err.message, `${hint}${preview}`, pointer].join('\n'));
+      }
+    });
+
+    return tree;
+  }
+}

--- a/src/core/BooleanSelector.ts
+++ b/src/core/BooleanSelector.ts
@@ -51,6 +51,19 @@ type Processor = (output: Output, character: string) => void;
  * to use a character outside of this set will result in a `SyntaxError`.
  */
 export class BooleanSelector {
+  /**
+   * Helper selector that matches any identifier on any level.
+   *
+   * @example
+   * BooleanSelector.True.matches('anything') // => true
+   * BooleanSelector.True.zoom('thing').matches('stuff') // => true
+   *
+   * @returns `BooleanSelector` singleton
+   */
+  static get True(): BooleanSelector {
+    return trueBooleanSelectorSingleton;
+  }
+
   private static __processors: Record<Entity, Processor> = {
     [Entity.List](output, character) {
       /* istanbul ignore next */
@@ -212,3 +225,19 @@ export class BooleanSelector {
     return tree;
   }
 }
+
+class TrueBooleanSelector extends BooleanSelector {
+  matches(): boolean {
+    return true;
+  }
+
+  zoom(): this {
+    return this;
+  }
+
+  toAttribute(): string | null {
+    return '';
+  }
+}
+
+const trueBooleanSelectorSingleton = new TrueBooleanSelector('');

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,5 +5,6 @@ export type { Graph } from './Graph';
 
 export * as Nucleon from './Nucleon/index.js';
 
+export { BooleanSelector } from './BooleanSelector.js';
 export { Rumour } from './Rumour/index.js';
 export { API } from './API/index.js';

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -121,5 +121,11 @@ describe('Core', () => {
       expect(selector.matches('baz')).toBe(false);
       expect(selector.matches('qux')).toBe(true);
     });
+
+    it('has static property True exposing wildcard selector', () => {
+      expect(BooleanSelector.True.matches('foo')).toBe(true);
+      expect(BooleanSelector.True.zoom('foo').matches('bar')).toBe(true);
+      expect(BooleanSelector.True.toAttribute()).toBe('');
+    });
   });
 });

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable sort-keys */
+
+import { BooleanSelector } from '../../src/core';
+
+describe('Core', () => {
+  describe('BooleanSelector', () => {
+    it('supports empty lists', () => {
+      const selector = new BooleanSelector('not=bar');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+    });
+
+    it('supports simple lists with not= modifier', () => {
+      const selector = new BooleanSelector('not=bar');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+    });
+
+    it('supports simple lists with simple items', () => {
+      const selector = new BooleanSelector('foo');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+    });
+
+    it('supports simple lists with complex items', () => {
+      const selector = new BooleanSelector('foo:bar');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+
+      expect(selector.filter('foo').allows('bar')).toBe(true);
+      expect(selector.filter('foo').allows('baz')).toBe(false);
+    });
+
+    it('supports simple lists with complex items and not= modifier', () => {
+      const selector = new BooleanSelector('foo:not=bar');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+
+      expect(selector.filter('foo').allows('bar')).toBe(false);
+      expect(selector.filter('foo').allows('baz')).toBe(true);
+    });
+
+    it('supports complex lists with complex items and complex not= modifier', () => {
+      const selector = new BooleanSelector('foo:not=bar,baz qux');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(false);
+      expect(selector.allows('baz')).toBe(false);
+      expect(selector.allows('qux')).toBe(true);
+
+      expect(selector.filter('foo').allows('bar')).toBe(false);
+      expect(selector.filter('foo').allows('baz')).toBe(false);
+      expect(selector.filter('foo').allows('any')).toBe(true);
+    });
+
+    it('throws on invalid list syntax', () => {
+      expect(() => new BooleanSelector('ага')).toThrow(SyntaxError);
+    });
+
+    it('throws on unknown modifier', () => {
+      expect(() => new BooleanSelector('foo:baz=qux')).toThrow(SyntaxError);
+    });
+
+    it('throws on invalid set syntax', () => {
+      expect(() => new BooleanSelector('not=crêpe')).toThrow(SyntaxError);
+    });
+
+    it('outputs original input string from .toString()', () => {
+      const input = 'foo:not=bar,baz qux';
+      expect(new BooleanSelector(input).toString()).toBe(input);
+    });
+
+    it('outputs generated input string from .toString()', () => {
+      const input = 'foo:bar:not=baz,qux quux';
+      const res = 'bar:not=baz,qux';
+      expect(new BooleanSelector(input).filter('foo').toString()).toBe(res);
+    });
+
+    it('tolerates excessive use of whitespace in lists', () => {
+      const selector = new BooleanSelector('  foo   bar ');
+
+      expect(selector.allows('foo')).toBe(true);
+      expect(selector.allows('bar')).toBe(true);
+      expect(selector.allows('baz')).toBe(false);
+    });
+
+    it('tolerates excessive use of whitespace in sets', () => {
+      const selector = new BooleanSelector(' not=foo,    bar ');
+
+      expect(selector.allows('foo')).toBe(false);
+      expect(selector.allows('bar')).toBe(false);
+      expect(selector.allows('baz')).toBe(true);
+    });
+
+    it('merges lists together', () => {
+      const selector = new BooleanSelector('foo:bar foo:baz');
+
+      expect(selector.filter('foo').allows('bar')).toBe(true);
+      expect(selector.filter('foo').allows('baz')).toBe(true);
+      expect(selector.filter('foo').allows('qux')).toBe(false);
+    });
+
+    it('merges sets together', () => {
+      const selector = new BooleanSelector('not=bar not=baz');
+
+      expect(selector.allows('bar')).toBe(false);
+      expect(selector.allows('baz')).toBe(false);
+      expect(selector.allows('qux')).toBe(true);
+    });
+  });
+});

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -81,6 +81,15 @@ describe('Core', () => {
       expect(new BooleanSelector(input).zoom('foo').toString()).toBe(res);
     });
 
+    it('outputs null from .toAttribute() for empty selectors', () => {
+      expect(new BooleanSelector('').toAttribute()).toBeNull();
+    });
+
+    it('outputs original input from .toAttribute() for non-empty selectors', () => {
+      const input = 'foo:bar:not=baz,qux quux';
+      expect(new BooleanSelector(input).toAttribute()).toBe(input);
+    });
+
     it('tolerates excessive use of whitespace in lists', () => {
       const selector = new BooleanSelector('  foo   bar ');
 

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -133,5 +133,26 @@ describe('Core', () => {
       expect(BooleanSelector.False.zoom('foo').matches('bar')).toBe(false);
       expect(BooleanSelector.False.toAttribute()).toBeNull();
     });
+
+    it('returns BooleanSelector.False from BooleanSelector.fromAttribute if value is null', () => {
+      expect(BooleanSelector.fromAttribute(null)).toBe(BooleanSelector.False);
+    });
+
+    it('returns BooleanSelector.True from BooleanSelector.fromAttribute if value is empty string', () => {
+      expect(BooleanSelector.fromAttribute('')).toBe(BooleanSelector.True);
+    });
+
+    it('returns BooleanSelector.True from BooleanSelector.fromAttribute if value is custom truthy value', () => {
+      expect(BooleanSelector.fromAttribute('readonly', 'readonly')).toBe(BooleanSelector.True);
+      expect(BooleanSelector.fromAttribute('readonly', 'disabled')).not.toBe(BooleanSelector.True);
+    });
+
+    it('returns BooleanSelector instance from BooleanSelector.fromAttribute for custom input', () => {
+      const input = 'foo:bar baz:not=qux';
+      const instance = BooleanSelector.fromAttribute(input);
+
+      expect(instance).toBeInstanceOf(BooleanSelector);
+      expect(instance.toString()).toBe(input);
+    });
   });
 });

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -7,55 +7,55 @@ describe('Core', () => {
     it('supports empty lists', () => {
       const selector = new BooleanSelector('not=bar');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
     });
 
     it('supports simple lists with not= modifier', () => {
       const selector = new BooleanSelector('not=bar');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
     });
 
     it('supports simple lists with simple items', () => {
       const selector = new BooleanSelector('foo');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
     });
 
     it('supports simple lists with complex items', () => {
       const selector = new BooleanSelector('foo:bar');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
 
-      expect(selector.filter('foo').allows('bar')).toBe(true);
-      expect(selector.filter('foo').allows('baz')).toBe(false);
+      expect(selector.zoom('foo').matches('bar')).toBe(true);
+      expect(selector.zoom('foo').matches('baz')).toBe(false);
     });
 
     it('supports simple lists with complex items and not= modifier', () => {
       const selector = new BooleanSelector('foo:not=bar');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
 
-      expect(selector.filter('foo').allows('bar')).toBe(false);
-      expect(selector.filter('foo').allows('baz')).toBe(true);
+      expect(selector.zoom('foo').matches('bar')).toBe(false);
+      expect(selector.zoom('foo').matches('baz')).toBe(true);
     });
 
     it('supports complex lists with complex items and complex not= modifier', () => {
       const selector = new BooleanSelector('foo:not=bar,baz qux');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(false);
-      expect(selector.allows('baz')).toBe(false);
-      expect(selector.allows('qux')).toBe(true);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
+      expect(selector.matches('baz')).toBe(false);
+      expect(selector.matches('qux')).toBe(true);
 
-      expect(selector.filter('foo').allows('bar')).toBe(false);
-      expect(selector.filter('foo').allows('baz')).toBe(false);
-      expect(selector.filter('foo').allows('any')).toBe(true);
+      expect(selector.zoom('foo').matches('bar')).toBe(false);
+      expect(selector.zoom('foo').matches('baz')).toBe(false);
+      expect(selector.zoom('foo').matches('any')).toBe(true);
     });
 
     it('throws on invalid list syntax', () => {
@@ -78,39 +78,39 @@ describe('Core', () => {
     it('outputs generated input string from .toString()', () => {
       const input = 'foo:bar:not=baz,qux quux';
       const res = 'bar:not=baz,qux';
-      expect(new BooleanSelector(input).filter('foo').toString()).toBe(res);
+      expect(new BooleanSelector(input).zoom('foo').toString()).toBe(res);
     });
 
     it('tolerates excessive use of whitespace in lists', () => {
       const selector = new BooleanSelector('  foo   bar ');
 
-      expect(selector.allows('foo')).toBe(true);
-      expect(selector.allows('bar')).toBe(true);
-      expect(selector.allows('baz')).toBe(false);
+      expect(selector.matches('foo')).toBe(true);
+      expect(selector.matches('bar')).toBe(true);
+      expect(selector.matches('baz')).toBe(false);
     });
 
     it('tolerates excessive use of whitespace in sets', () => {
       const selector = new BooleanSelector(' not=foo,    bar ');
 
-      expect(selector.allows('foo')).toBe(false);
-      expect(selector.allows('bar')).toBe(false);
-      expect(selector.allows('baz')).toBe(true);
+      expect(selector.matches('foo')).toBe(false);
+      expect(selector.matches('bar')).toBe(false);
+      expect(selector.matches('baz')).toBe(true);
     });
 
     it('merges lists together', () => {
       const selector = new BooleanSelector('foo:bar foo:baz');
 
-      expect(selector.filter('foo').allows('bar')).toBe(true);
-      expect(selector.filter('foo').allows('baz')).toBe(true);
-      expect(selector.filter('foo').allows('qux')).toBe(false);
+      expect(selector.zoom('foo').matches('bar')).toBe(true);
+      expect(selector.zoom('foo').matches('baz')).toBe(true);
+      expect(selector.zoom('foo').matches('qux')).toBe(false);
     });
 
     it('merges sets together', () => {
       const selector = new BooleanSelector('not=bar not=baz');
 
-      expect(selector.allows('bar')).toBe(false);
-      expect(selector.allows('baz')).toBe(false);
-      expect(selector.allows('qux')).toBe(true);
+      expect(selector.matches('bar')).toBe(false);
+      expect(selector.matches('baz')).toBe(false);
+      expect(selector.matches('qux')).toBe(true);
     });
   });
 });

--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -127,5 +127,11 @@ describe('Core', () => {
       expect(BooleanSelector.True.zoom('foo').matches('bar')).toBe(true);
       expect(BooleanSelector.True.toAttribute()).toBe('');
     });
+
+    it('has static property False exposing inverse wildcard selector', () => {
+      expect(BooleanSelector.False.matches('foo')).toBe(false);
+      expect(BooleanSelector.False.zoom('foo').matches('bar')).toBe(false);
+      expect(BooleanSelector.False.toAttribute()).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Boolean selector is an HTML boolean attribute value format that allows developers to write configurations for elements deep in a shadow DOM. Here's what it looks like:

```text
direct-child-one:nested-child:not=descendant-one,descendant-two direct-child-two
```

When used with the "disabled" attribute, the code above could translate to: "Disable everything except for the descendant-one and descendant-two in the nested-child that belongs to direct-child-one; disable direct-child-two entirely."

Boolean selector is always a list, where items are separated by whitespace (as much as you need, including line breaks):

```text
item-one item-two item-three
```

Each item is a path that consists of identifiers (lowercase characters from a to z or a dash) separated by a colon:

```text
parent:child:nested-child
```

By default, only specified paths will be selected. To select everything except for certain paths, add the `not=` modifier to the end of the path (or at the top level):

```text
parent:child:not=exception
```

You can specify multiple values by separating them with a comma and optionally a whitespace:

```text
parent:child:not=exception-one, exception-two
```

Only lowercase a-z letters, colon, comma, dash and whitespace are allowed in the selectors. An attempt to use a character outside of this set will result in a `SyntaxError`.