### PR TITLE
fix: make cc info nullable in type definition

### DIFF
--- a/src/backend/Graph/default_payment_method.d.ts
+++ b/src/backend/Graph/default_payment_method.d.ts
@@ -18,15 +18,15 @@ export interface DefaultPaymentMethod extends Graph {
     /** If the customer selected to save their payment information, this will be true. To clear out the payment information, set this to false. */
     save_cc: boolean;
     /** The credit card or debit card type. This will be determined automatically once the payment card is saved. */
-    cc_type: string;
+    cc_type: string | null;
     /** The payment card number. This property will not be displayed as part of this resource, but can be used to modify this payment method. */
-    cc_number: number;
+    cc_number?: number;
     /** A masked version of this payment card showing only the last 4 digits. */
-    cc_number_masked: string;
+    cc_number_masked: string | null;
     /** The payment card expiration month in the MM format. */
-    cc_exp_month: string;
+    cc_exp_month: string | null;
     /** The payment card expiration year in the YYYY format. */
-    cc_exp_year: string;
+    cc_exp_year: string | null;
     /** The date this resource was created. */
     date_created: string;
     /** The date this resource was last modified. */

--- a/src/backend/Graph/payment.d.ts
+++ b/src/backend/Graph/payment.d.ts
@@ -28,11 +28,11 @@ export interface Payment extends Graph {
     /** The masked credit card number used for this payment (for plastic payment types). */
     cc_number_masked: string;
     /** The type of credit card such as Visa or MasterCard (for plastic payment types). */
-    cc_type: string;
+    cc_type: string | null;
     /** The credit card expiration month (for plastic payment types). */
-    cc_exp_month: string;
+    cc_exp_month: string | null;
     /** The credit card expiration year (for plastic payment types). */
-    cc_exp_year: string;
+    cc_exp_year: string | null;
     /** If this payment gateway set is configured with a fraud protection system, the fraud score for this payment will be listed here. */
     fraud_protection_score: number;
     /** The payer id for this payment (for Paypal payment types). */

--- a/src/customer/Graph/default_payment_method.d.ts
+++ b/src/customer/Graph/default_payment_method.d.ts
@@ -14,15 +14,15 @@ export interface DefaultPaymentMethod extends Graph {
     /** If the customer selected to save their payment information, this will be true. To clear out the payment information, set this to false. */
     save_cc: boolean;
     /** The credit card or debit card type. This will be determined automatically once the payment card is saved. */
-    cc_type: string;
+    cc_type: string | null;
     /** The payment card number. This property will not be displayed as part of this resource, but can be used to modify this payment method. */
-    cc_number: number;
+    cc_number?: number;
     /** A masked version of this payment card showing only the last 4 digits. */
-    cc_number_masked: string;
+    cc_number_masked: string | null;
     /** The payment card expiration month in the MM format. */
-    cc_exp_month: string;
+    cc_exp_month: string | null;
     /** The payment card expiration year in the YYYY format. */
-    cc_exp_year: string;
+    cc_exp_year: string | null;
     /** The date this resource was created. */
     date_created: string;
     /** The date this resource was last modified. */


### PR DESCRIPTION
Not every payment method includes info about `cc_type`, `cc_exp_year` etc – some have `null` values for them. We've come across this in the Stencil portal, but the fix never made it to the SDK, as it appears. This PR corrects type definitions and makes it possible to fix https://github.com/Foxy/foxy-elements/issues/60.