### PR TITLE
feat(nucleon): add `REFRESH` event

### DIFF
--- a/src/core/Nucleon/machine.ts
+++ b/src/core/Nucleon/machine.ts
@@ -19,6 +19,7 @@ export const machine = createMachine<Context, Event, State>(
     on: {
       DELETE: { actions: ['clearData', 'clearEdits', 'clearErrors'], target: '#nucleon.busy.deleting' },
       FETCH: { actions: ['clearData', 'clearEdits', 'clearErrors'], target: '#nucleon.busy.fetching' },
+      REFRESH: { target: '#nucleon.busy.fetching' },
       SET_DATA: { actions: ['setData', 'clearEdits', 'clearErrors'], target: '#nucleon.init' },
     },
     states: {

--- a/src/core/Nucleon/types.d.ts
+++ b/src/core/Nucleon/types.d.ts
@@ -28,6 +28,7 @@ export type Context<TData extends Data = Data, TError = unknown, TFailure = unkn
  */
 export type Event<TData extends Data = Data> =
   | { type: 'SET_DATA'; data: TData | null }
+  | { type: 'REFRESH' }
   | { type: 'EDIT'; data: Partial<TData> }
   | { type: 'UNDO' }
   | { type: 'FETCH' }
@@ -51,7 +52,7 @@ export type State<TData extends Data = Data, TError = unknown, TFailure = unknow
     }
   | {
       value: { busy: 'fetching' };
-      context: Context<TData, TError> & { data: null; edits: null; failure: null };
+      context: Context<TData, TError> & { failure: null };
     }
   | {
       value: { busy: 'creating' };


### PR DESCRIPTION
This PR adds a `REFRESH` event to the Nucleon state machine. The event triggers a reload but keeps existing resource data, edits and validation errors while the new content is being fetched. This behaviour will be used in Elements for Rumour updates instead of `FETCH`.