### PR TITLE
fix: set default sso url expiration date to 1 hour from now

### DIFF
--- a/src/backend/createSSOURL.ts
+++ b/src/backend/createSSOURL.ts
@@ -5,12 +5,14 @@ import v8n from 'v8n';
 
 interface Options {
   /**
-   * Integer, epoch time. The future time that this authentication token will expire.
+   * Integer, epoch time (seconds). The future time that this authentication token will expire.
    * If a customer makes a checkout request with an expired authentication token, then FoxyCart
    * will redirect them to the endpoint in order to generate a new token. You can make use of the
    * timestamp value you received to your endpoint in the GET parameters, and add additional time
    * to it for how long you want it to be valid for. For example, adding 3600 to the timestamp will
-   * extend it by 3600 seconds, or 30 minutes.
+   * extend it by 3600 seconds, or 60 minutes.
+   *
+   * Defaults to an hour from now.
    *
    * @see https://docs.foxycart.com/v/2.0/sso#the_details
    */
@@ -77,7 +79,7 @@ const optionsV8N = v8n().schema({
 export function createSSOURL(options: Options): string {
   optionsV8N.check(options);
 
-  const timestamp = options.timestamp ?? Date.now();
+  const timestamp = options.timestamp ?? Math.floor(Date.now() / 1000) + 3600;
   const decodedToken = `${options.customer}|${timestamp}|${options.secret}`;
   const encodedToken = crypto.createHash('sha1').update(decodedToken);
   const url = new URL('/checkout', options.domain);

--- a/tests/backend/createSSOURL.test.ts
+++ b/tests/backend/createSSOURL.test.ts
@@ -24,7 +24,7 @@ describe('Backend', () => {
       });
 
       expect(url).toBe(
-        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=097e56e8db16788ec90b4857439098adc3fa8cb2&timestamp=1585402055672'
+        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=fe55dd1299ce7db668bd43ee3284e823a84fe3b3&timestamp=1585405655'
       );
     });
 
@@ -33,11 +33,11 @@ describe('Backend', () => {
         customer: 12345,
         domain: 'https://foxy-demo.foxycart.com',
         secret: 'yes, very',
-        timestamp: 1595406051672,
+        timestamp: 1595406051,
       });
 
       expect(url).toBe(
-        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=2682b3c43e97c98efbe7102e5f46aea5ee81834c&timestamp=1595406051672'
+        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=0d26d6129051d4175ed76cba20914b8855327e63&timestamp=1595406051'
       );
     });
 
@@ -50,7 +50,7 @@ describe('Backend', () => {
       });
 
       expect(url).toBe(
-        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=097e56e8db16788ec90b4857439098adc3fa8cb2&timestamp=1585402055672&fcsid=so_awesomely_unique'
+        'https://foxy-demo.foxycart.com/checkout?fc_customer_id=12345&fc_auth_token=fe55dd1299ce7db668bd43ee3284e823a84fe3b3&timestamp=1585405655&fcsid=so_awesomely_unique'
       );
     });
   });


### PR DESCRIPTION
SSO expiration date needs to be in seconds, but the default value was in milliseconds, making SSO URLs valid for the next 50000 years if no custom `timestamp` was provided. Fixing that and adding a clarification to the JSDoc.