### PR TITLE
fix: correct customer api typedefs

### DIFF
--- a/src/customer/Graph/attribute.d.ts
+++ b/src/customer/Graph/attribute.d.ts
@@ -12,8 +12,6 @@ export interface Attribute extends Graph {
   };
 
   props: {
-    /** Controls who can see this attribute. Only public attributes are accessible via this API. */
-    visibility: 'public';
     /** The name of this attribute. */
     name: string;
     /** The value of this attribute. */

--- a/src/customer/Graph/custom_field.d.ts
+++ b/src/customer/Graph/custom_field.d.ts
@@ -1,0 +1,24 @@
+import type { Graph } from '../../core';
+import type { Transaction } from './transaction';
+
+export interface CustomField extends Graph {
+  curie: 'fx:custom_field';
+
+  links: {
+    /** This resource. */
+    'self': CustomField;
+    /** Transaction this custom field is linked to. */
+    'fx:transaction': Transaction;
+  };
+
+  props: {
+    /** The name of the custom field. */
+    name: string;
+    /** The value of this custom field. */
+    value: string;
+    /** The date this resource was created. */
+    date_created: string | null;
+    /** The date this resource was last modified. */
+    date_modified: string | null;
+  };
+}

--- a/src/customer/Graph/custom_fields.d.ts
+++ b/src/customer/Graph/custom_fields.d.ts
@@ -1,0 +1,10 @@
+import type { CollectionGraphLinks, CollectionGraphProps } from '../../core/defaults';
+import type { CustomField } from './custom_field';
+import type { Graph } from '../../core';
+
+export interface CustomFields extends Graph {
+  curie: 'fx:custom_fields';
+  links: CollectionGraphLinks<CustomFields>;
+  props: CollectionGraphProps;
+  child: CustomField;
+}

--- a/src/customer/Graph/transaction.d.ts
+++ b/src/customer/Graph/transaction.d.ts
@@ -1,4 +1,5 @@
 import type { Attributes } from './attributes';
+import type { CustomFields } from './custom_fields';
 import type { Graph as Customer } from './index';
 import type { Graph } from '../../core';
 import type { Items } from './items';
@@ -15,6 +16,8 @@ export interface Transaction extends Graph {
     'fx:customer': Customer;
     /** List of custom attributes on this transaction. */
     'fx:attributes': Attributes;
+    /** List of custom fields on this transaction. */
+    'fx:custom_fields': CustomFields;
     /** List of items for this transaction. */
     'fx:items': Items;
   };
@@ -71,6 +74,7 @@ export interface Transaction extends Graph {
   };
 
   zooms: {
+    custom_fields?: CustomFields;
     attributes: Attributes;
     customer?: Customer;
     items?: Items;


### PR DESCRIPTION
This PR corrects type definitions to reflect changes in the latest Customer API update, adding support for `fx:custom_fields` on transactions and removing `visibility` property on `fx:attribute`.