### PR TITLE
fix: fix complex boolean selector resolution

### DIFF
--- a/tests/core/BooleanSelector.test.ts
+++ b/tests/core/BooleanSelector.test.ts
@@ -68,7 +68,7 @@ describe('Core', () => {
     it('supports complex ids in .zoom()', () => {
       const selector = new BooleanSelector('foo:bar:baz:qux');
 
-      expect(selector.zoom('foo:bar').toString()).toBe('baz:qux:not=*');
+      expect(selector.zoom('foo:bar').toString()).toBe('baz:qux');
       expect(selector.zoom('baz:qux').toString()).toBe('');
     });
 
@@ -133,14 +133,6 @@ describe('Core', () => {
       expect(selector.zoom('foo').matches('bar')).toBe(true);
       expect(selector.zoom('foo').matches('baz')).toBe(true);
       expect(selector.zoom('foo').matches('qux')).toBe(false);
-    });
-
-    it('merges sets together', () => {
-      const selector = new BooleanSelector('not=bar not=baz');
-
-      expect(selector.matches('bar')).toBe(false);
-      expect(selector.matches('baz')).toBe(false);
-      expect(selector.matches('qux')).toBe(true);
     });
 
     it('prefers wildcard over detailed rules in sets', () => {


### PR DESCRIPTION
This PR fixes a long-standing issue in BooleanSelector where the parser would attempt to merge complex or conflicting selectors, resulting in unpredictable behavior. 

In this update, BooleanSelector will produce intermediate results for each item in the list of paths, merging complex rules one step at a time instead of looking at the selector as a whole. This will allow users to mix complex allowlist/blocklist-style rules with predictable results. Additionally, unlike the previous version, this one won't let overrides "unselect" IDs by inserting a cleverly constructed `not=` modifer – every override can only narrow the resulting set.