### PR TITLE
chore: release v1.9.4

### DIFF
--- a/src/backend/Graph/language_strings.d.ts
+++ b/src/backend/Graph/language_strings.d.ts
@@ -15,6 +15,6 @@ export interface LanguageStrings extends Graph {
     /** A small, human readable explanation of this property helper. */
     message: string;
     /** JSON objects with the language strings supported. The key values match the language property and each pair represents the language_override `code` and `custom_value`. */
-    values: Record<string, Record<string, string>>;
+    values: Record<string, Record<string, string | Record<string, Record<string, string>>>>;
   };
 }

--- a/src/backend/Graph/store.d.ts
+++ b/src/backend/Graph/store.d.ts
@@ -107,9 +107,9 @@ export interface Store extends Graph {
     /** Used for when you want to specify a different from email than your store's email address or when your store_email has a list of email addresses. */
     from_email: string;
     /** Set this to true if you would like each receipt sent to your customer to also be blind carbon copied to your store's email address. */
-    bcc_on_receipt_email: string;
+    bcc_on_receipt_email: boolean;
     /** Set this to true if you have set up your DNS settings to include and spf record for FoxyCart. See the {@link http://wiki.foxycart.com/v/1.1/emails FoxyCart documentation} for more details. */
-    use_email_dns: string;
+    use_email_dns: boolean;
     /** If you'd like to configure your own SMTP server for sending transaction receipt emails, you can do so here. The JSON supports the following fields: `username`,`password`,`host`,`port`,`security`. The security value can be blank, `ssl`, or `tls` */
     smtp_config: string;
     /** The postal code of your store. This will be used for calculating shipping costs if you sell shippable items. */

--- a/src/backend/Graph/tax_item_category.d.ts
+++ b/src/backend/Graph/tax_item_category.d.ts
@@ -21,7 +21,7 @@ export interface TaxItemCategory extends Graph {
     /** A full API URI of the item category resource used in this relationship. When working with hypermedia, it's important to save URIs and not just numeric ids. */
     item_category_uri: string;
     /** A full API URI of the tax resource used in this relationship. When working with hypermedia, it's important to save URIs and not just numeric ids. */
-    store_uri: string;
+    tax_uri: string;
     /** The date this resource was created. */
     date_created: string | null;
     /** The date this resource was last modified. */

--- a/src/backend/Graph/template_set.d.ts
+++ b/src/backend/Graph/template_set.d.ts
@@ -6,6 +6,7 @@ import type { Graph } from '../../core';
 import type { LanguageOverrides } from './language_overrides';
 import type { ReceiptTemplate } from './receipt_template';
 import type { Store } from './store';
+import type { TemplateConfig } from './template_config';
 
 export interface TemplateSet extends Graph {
   curie: 'fx:template_set';
@@ -27,6 +28,8 @@ export interface TemplateSet extends Graph {
     'fx:language_overrides': LanguageOverrides;
     /** Cart include template for this template set. */
     'fx:cart_include_template': CartIncludeTemplate;
+    /** Template config for this template set. */
+    'fx:template_config': TemplateConfig;
   };
 
   props: {

--- a/src/core/Nucleon/machine.ts
+++ b/src/core/Nucleon/machine.ts
@@ -17,7 +17,7 @@ export const machine = createMachine<Context, Event, State>(
     id: 'nucleon',
     initial: 'init',
     on: {
-      DELETE: { actions: ['clearData', 'clearEdits', 'clearErrors'], target: '#nucleon.busy.deleting' },
+      DELETE: { target: '#nucleon.busy.deleting' },
       FETCH: { actions: ['clearData', 'clearEdits', 'clearErrors'], target: '#nucleon.busy.fetching' },
       REFRESH: { target: '#nucleon.busy.fetching' },
       SET_DATA: { actions: ['setData', 'clearEdits', 'clearErrors'], target: '#nucleon.init' },


### PR DESCRIPTION
- backend: add support for nested groups to the language strings property helper type
- backend: fix typedefs for `bcc_on_receipt_email and` `use_email_dns` on `fx:store`
- backend: fix a typo in the `fx:tax_item_category` typedefs where `store_uri` should've been `tax_uri`
- backend: add missing `fx:template_config` link to `fx:template_set` typedefs
- nucleon: don't clear data, edits and errors before the delete request