### PR TITLE
chore: release v1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "webpack-node-externals": "^2.5.2"
       },
       "engines": {
-        "node": ">=10 <=18"
+        "node": ">=10 <=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "webpack-node-externals": "^2.5.2"
   },
   "engines": {
-    "node": ">=10 <=18"
+    "node": ">=10 <=20"
   },
   "eslintConfig": {
     "extends": [

--- a/src/core/API/Node.ts
+++ b/src/core/API/Node.ts
@@ -128,8 +128,8 @@ export class Node<TGraph extends Graph> {
 
     if (filters !== undefined) {
       filters.forEach((filter: string) => {
-        const params = new URLSearchParams(filter);
-        [...params.entries()].forEach(([key, value]) => url.searchParams.append(key, value));
+        const [key, value = ''] = filter.split('=');
+        if (key) url.searchParams.append(key, value);
       });
     }
 

--- a/src/core/getResourceId.ts
+++ b/src/core/getResourceId.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the last path segment, which is usually an ID.
+ * If it's a non-NaN numeric ID (true for most Foxy resources) then a `number` is returned.
+ * Otherwise returns a string or `null` if the path is empty.
+ *
+ * @param uri `self` link on a resource, e.g. `https://api.foxy.io/stores/123`
+ * @returns resource ID or `null` if not found
+ */
+export function getResourceId(uri: string): string | number | null {
+  try {
+    const idAsString = new URL(uri).pathname.split('/').pop() || undefined;
+    if (idAsString === undefined) return null;
+    const idAsInt = parseInt(idAsString);
+    return isNaN(idAsInt) ? idAsString : idAsInt;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,5 +6,6 @@ export type { Graph } from './Graph';
 export * as Nucleon from './Nucleon/index.js';
 
 export { BooleanSelector } from './BooleanSelector.js';
+export { getResourceId } from './getResourceId.js';
 export { Rumour } from './Rumour/index.js';
 export { API } from './API/index.js';

--- a/tests/core/API/Node.test.ts
+++ b/tests/core/API/Node.test.ts
@@ -119,8 +119,8 @@ describe('Core', () => {
 
       testGET<{ child: never }>({
         label: 'GETs resolved URL with filters',
-        query: { filters: ['foo=bar', 'baz=qux'] },
-        target: 'https://example.com/?foo=bar&baz=qux',
+        query: { filters: ['foo=bar', 'baz=qux+one@example.com'] },
+        target: 'https://example.com/?foo=bar&baz=qux%2Bone%40example.com',
       });
 
       it('errors when .get() is called with incorrect query', async () => {

--- a/tests/core/getResourceId.test.ts
+++ b/tests/core/getResourceId.test.ts
@@ -1,0 +1,21 @@
+import { getResourceId } from '../../src/core';
+
+describe('Core', () => {
+  describe('getResourceId', () => {
+    it('supports numeric IDs', () => {
+      expect(getResourceId('https://api.foxy.io/stores/123')).toEqual(123);
+    });
+
+    it('supports string IDs', () => {
+      expect(getResourceId('https://api.foxy.io/stores/AB1')).toEqual('AB1');
+    });
+
+    it("returns null if there's no ID", () => {
+      expect(getResourceId('https://api.foxy.io')).toBeNull();
+    });
+
+    it('returns null if the provided URI is invalid', () => {
+      expect(getResourceId('this is definitely not a URI')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
- **build:** mark package as officially supporting node 20
- **feat:** add core `getResourceId()` helper
- **fix:** don't require filters to be url-encoded