### PR TITLE
feat: add support for Customer Registration API

### DIFF
--- a/src/backend/Graph/customer_portal_settings.d.ts
+++ b/src/backend/Graph/customer_portal_settings.d.ts
@@ -58,6 +58,20 @@ export interface CustomerPortalSettings extends Graph {
     ssoSecret?: string;
     /** Life span of session in minutes. Maximum 40320 (4 weeks). */
     sessionLifespanInMinutes: number;
+    /** Self-registration settings. Self-registration is disabled if this field is undefined. */
+    signUp?: {
+      /** If this field is true, then self-registration is enabled. */
+      enabled: boolean;
+      /** Client verification settings. */
+      verification: {
+        /** Verification type. Currently only hCaptcha is supported. */
+        type: 'hcaptcha';
+        /** hCaptcha site key. If empty, Foxy will use its own hCaptcha site key. */
+        siteKey: string;
+        /** hCaptcha secret key. If empty, Foxy will use its own hCaptcha secret key. */
+        secretKey: string;
+      };
+    };
     /** The date this resource was created. */
     date_created: string | null;
     /** The date this resource was last modified. */

--- a/src/core/API/AuthError.ts
+++ b/src/core/API/AuthError.ts
@@ -11,6 +11,8 @@ type UniversalAPIAuthErrorCode =
   | typeof AuthError['NEW_PASSWORD_REQUIRED']
   | typeof AuthError['INVALID_NEW_PASSWORD']
   | typeof AuthError['UNAUTHORIZED']
+  | typeof AuthError['INVALID_FORM']
+  | typeof AuthError['UNAVAILABLE']
   | typeof AuthError['UNKNOWN'];
 
 /**
@@ -29,6 +31,12 @@ export class AuthError extends Error {
   /** Credentials are invalid. That could mean empty or invalid email or password or otherwise incorrect auth data. */
   static readonly UNAUTHORIZED = 'UNAUTHORIZED';
 
+  /** Provided form data is invalid, e.g. email is too long or captcha is expired. */
+  static readonly INVALID_FORM = 'INVALID_FORM';
+
+  /** Provided email is already taken. Applies to customer registration only. */
+  static readonly UNAVAILABLE = 'UNAVAILABLE';
+
   /** Any other or internal error that interrupted authentication. */
   static readonly UNKNOWN = 'UNKNOWN';
 
@@ -39,6 +47,8 @@ export class AuthError extends Error {
         v8n().exact(AuthError.NEW_PASSWORD_REQUIRED),
         v8n().exact(AuthError.INVALID_NEW_PASSWORD),
         v8n().exact(AuthError.UNAUTHORIZED),
+        v8n().exact(AuthError.INVALID_FORM),
+        v8n().exact(AuthError.UNAVAILABLE),
         v8n().exact(AuthError.UNKNOWN)
       ),
     }),

--- a/src/customer/Graph/customer_portal_settings.d.ts
+++ b/src/customer/Graph/customer_portal_settings.d.ts
@@ -53,6 +53,29 @@ export interface CustomerPortalSettings extends Graph {
     sso: boolean;
     /** Life span of session in minutes. Maximum 40320 (4 weeks). */
     session_lifespan_in_minutes: number;
+    /** Determines if a terms of service checkbox is shown on the portal. This value comes from a template config linked to the default template set. */
+    tos_checkbox_settings: {
+      /** Initial state of the checkbox element. */
+      initial_state: 'unchecked' | 'checked';
+      /** Hides the checkbox if true. */
+      is_hidden: boolean;
+      /** Hides the checkbox if "none". Makes accepting ToS mandatory if "required", and optional otherwise. */
+      usage: 'none' | 'optional' | 'required';
+      /** Public URL of your terms of service agreement. */
+      url: string;
+    };
+    /** Self-registration settings. Self-registration is disabled if this field is undefined. */
+    sign_up?: {
+      /** Client verification settings. */
+      verification: {
+        /** hCaptcha site key. If empty, Foxy will use its own hCaptcha site key. */
+        site_key: string;
+        /** Verification type. Currently only hCaptcha is supported. */
+        type: 'hcaptcha';
+      };
+      /** If this field is true, then self-registration is enabled. */
+      enabled: boolean;
+    };
     /** The date this resource was created. */
     date_created: string | null;
     /** The date this resource was last modified. */

--- a/src/customer/types.d.ts
+++ b/src/customer/types.d.ts
@@ -6,6 +6,25 @@ export interface Credentials {
   password: string;
 }
 
+/** Account creation parameters. */
+export interface SignUpParams {
+  /** Signup verification (currently only hCaptcha is supported). */
+  verification: {
+    /** Verification type. Currently only hCaptcha is supported. */
+    type: 'hcaptcha';
+    /** hCaptcha verification token. */
+    token: string;
+  };
+  /** Customer's first name, optional, up to 50 characters. */
+  first_name?: string;
+  /** Customer's last name, optional, up to 50 characters. */
+  last_name?: string;
+  /** Customer's password (up to 50 characters). If not provided, Foxy will generate a random password for this account server-side. */
+  password?: string;
+  /** Customer's email address (up to 100 characters), required. */
+  email: string;
+}
+
 export interface Session {
   session_token: string;
   expires_in: number;

--- a/tests/core/API/AuthError.test.ts
+++ b/tests/core/API/AuthError.test.ts
@@ -7,6 +7,8 @@ describe('Core', () => {
         expect(AuthError).toHaveProperty('NEW_PASSWORD_REQUIRED');
         expect(AuthError).toHaveProperty('INVALID_NEW_PASSWORD');
         expect(AuthError).toHaveProperty('UNAUTHORIZED');
+        expect(AuthError).toHaveProperty('INVALID_FORM');
+        expect(AuthError).toHaveProperty('UNAVAILABLE');
         expect(AuthError).toHaveProperty('UNKNOWN');
       });
 


### PR DESCRIPTION
This PR updates type definitions for `fx:customer_portal_settings` (Customer and Backend APIs) and adds a new method to `SDK.Customer` in preparation for enabling the customer self-registration functionality on the portal.