### PR TITLE
build: add missing imports to docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "ts-node": "^9.1.1",
         "ttypescript": "^1.5.15",
         "typedoc": "^0.22.18",
+        "typedoc-plugin-missing-exports": "^1.0.0",
         "typescript": "^4.0.3",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0",
@@ -11644,7 +11645,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -11660,19 +11660,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11687,7 +11684,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -11705,7 +11701,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -17122,6 +17117,15 @@
       },
       "peerDependencies": {
         "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-1.0.0.tgz",
+      "integrity": "sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x || 0.23.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -27055,8 +27059,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -27069,18 +27072,15 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -27092,8 +27092,7 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -27107,8 +27106,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -31530,6 +31528,13 @@
           }
         }
       }
+    },
+    "typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-1.0.0.tgz",
+      "integrity": "sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ts-node": "^9.1.1",
     "ttypescript": "^1.5.15",
     "typedoc": "^0.22.18",
+    "typedoc-plugin-missing-exports": "^1.0.0",
     "typescript": "^4.0.3",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",


### PR DESCRIPTION
This PR fixes an issue in doc generation where the referenced types were not included.